### PR TITLE
Fixed kanji grade bug. bug: grade does exception and is always None.

### DIFF
--- a/jisho_api/kanji/request.py
+++ b/jisho_api/kanji/request.py
@@ -326,7 +326,7 @@ class Kanji:
 
         if cache and (Kanji.ROOT / (kanji + ".json")).exists():
             toggle = True
-            with open(Kanji.ROOT / (kanji + ".json"), "r") as fp:
+            with open(Kanji.ROOT / (kanji + ".json"), "r", encoding="utf-8") as fp:
                 r = json.load(fp)
             r = KanjiRequest(**r)
         else:
@@ -362,5 +362,5 @@ class Kanji:
     @staticmethod
     def save(word, r):
         Kanji.ROOT.mkdir(exist_ok=True)
-        with open(Kanji.ROOT / f"{word}.json", "w") as fp:
+        with open(Kanji.ROOT / f"{word}.json", "w", encoding="utf-8") as fp:
             json.dump(r.dict(), fp, indent=4, ensure_ascii=False)

--- a/jisho_api/kanji/request.py
+++ b/jisho_api/kanji/request.py
@@ -146,7 +146,6 @@ class Kanji:
 
     @staticmethod
     def meta(soup):
-        res = soup.find_all("div", {"class": "kanji_stats"})[0].find_all("strong")
         return {
             "education": Kanji.meta_education(soup),
             "dictionary_idxs": Kanji.meta_dictionary_idxs(soup),
@@ -211,25 +210,31 @@ class Kanji:
 
     @staticmethod
     def meta_education(soup):
-        res = soup.find_all("div", {"class": "kanji_stats"})[0]  # .find_all("strong")
+        res = soup.find_all("div", {"class": "kanji_stats"})[0]  # .find_all("strong")[0]
 
         try:
             grade = (
                 res.find_all("div", {"class": "grade"})[0]
-                .find_all("strong")
-                .text.split(" ")[-1]
+                .find_all("strong")[0]
+                .text # the grade is sometimes "junior high". shouldn't use .split(" ")[-1]
             )
         except:
             grade = None
 
         try:
-            jlpt = res.find_all("div", {"class": "jlpt"})[0].find_all("strong").text
+            jlpt = (
+                res.find_all("div", {"class": "jlpt"})[0]
+                .find_all("strong")[0]
+                .text
+            )
         except:
             jlpt = None
 
         try:
             frequency = (
-                res.find_all("div", {"class": "frequency"})[0].find_all("strong").text
+                res.find_all("div", {"class": "frequency"})[0]
+                .find_all("strong")[0]
+                .text
             )
         except:
             frequency = None

--- a/jisho_api/sentence/request.py
+++ b/jisho_api/sentence/request.py
@@ -74,7 +74,7 @@ class Sentence:
 
         if cache and (Sentence.ROOT / (word + ".json")).exists():
             toggle = True
-            with open(Sentence.ROOT / (word + ".json"), "r") as fp:
+            with open(Sentence.ROOT / (word + ".json"), "r", encoding="utf-8") as fp:
                 r = json.load(fp)
             r = SentenceRequest(**r)
         else:
@@ -99,5 +99,5 @@ class Sentence:
     @staticmethod
     def save(word, r):
         Sentence.ROOT.mkdir(exist_ok=True)
-        with open(Sentence.ROOT / f"{word}.json", "w") as fp:
+        with open(Sentence.ROOT / f"{word}.json", "w", encoding="utf-8") as fp:
             json.dump(r.dict(), fp, indent=4, ensure_ascii=False)

--- a/jisho_api/tokenize/request.py
+++ b/jisho_api/tokenize/request.py
@@ -72,7 +72,7 @@ class Tokens:
 
         if cache and (Tokens.ROOT / (word + ".json")).exists():
             toggle = True
-            with open(Tokens.ROOT / (word + ".json"), "r") as fp:
+            with open(Tokens.ROOT / (word + ".json"), "r", encoding="utf-8") as fp:
                 r = json.load(fp)
             r = TokenRequest(**r)
         else:
@@ -97,5 +97,5 @@ class Tokens:
     @staticmethod
     def save(word, r):
         Tokens.ROOT.mkdir(exist_ok=True)
-        with open(Tokens.ROOT / f"{word}.json", "w") as fp:
+        with open(Tokens.ROOT / f"{word}.json", "w", encoding="utf-8") as fp:
             json.dump(r.dict(), fp, indent=4, ensure_ascii=False)

--- a/jisho_api/word/request.py
+++ b/jisho_api/word/request.py
@@ -67,7 +67,7 @@ class Word:
 
         if cache and (Word.ROOT / (word + ".json")).exists():
             toggle = True
-            with open(Word.ROOT / (word + ".json"), "r") as fp:
+            with open(Word.ROOT / (word + ".json"), "r", encoding="utf-8") as fp:
                 r = json.load(fp)
         else:
             r = requests.get(url, headers=headers).json()
@@ -83,5 +83,5 @@ class Word:
     @staticmethod
     def save(word, r):
         Word.ROOT.mkdir(exist_ok=True)
-        with open(Word.ROOT / f"{word}.json", "w") as fp:
+        with open(Word.ROOT / f"{word}.json", "w", encoding="utf-8") as fp:
             fp.write(json.dumps(r.dict(), indent=4, ensure_ascii=False))


### PR DESCRIPTION
The kanji grade always returns None because of an error within the find_all method.

Error: "ResultSet object has no attribute 'text'. You're probably treating a list of elements like a single element. Did you call find_all() when you meant to call find()?"

There were 2 fixes I found.
Fix 1. call find() instead.
Fix 2. call find_all() indexed by 0. ex. `find_all()[0]`

Additional.
Removed 1 unused line.
Removed the split method. Causes problem with grade. (comment was added that explains it. Feel free to remove it)